### PR TITLE
Normalize membership root to bytes32 string

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,15 +2,13 @@
 "use client";
 import { useState } from "react";
 import { ethers } from "ethers";
+import type { Eip1193Provider } from "ethers";
 
-interface EthereumProvider {
-  isMetaMask?: boolean;
-  request?: (args: { method: string; params?: Array<any> }) => Promise<any>;
-}
+type ExtendedEthereumProvider = Eip1193Provider & { isMetaMask?: boolean };
 
 declare global {
   interface Window {
-    ethereum?: EthereumProvider;
+    ethereum?: ExtendedEthereumProvider;
   }
 }
 
@@ -24,8 +22,8 @@ export default function Page() {
       return;
     }
     try {
-      const provider = new ethers.BrowserProvider(window.ethereum as any);
-      const accounts = await provider.send("eth_requestAccounts", []);
+      const provider = new ethers.BrowserProvider(window.ethereum);
+      const accounts = (await provider.send("eth_requestAccounts", [])) as string[];
       setAccount(accounts[0]);
       setError(null);
     } catch (err) {

--- a/app/src/app/vote/page.tsx
+++ b/app/src/app/vote/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from 'react';
 import { proveMembership } from '../../lib/zk';
+import type { MembershipProof } from '../../lib/zk';
 import { castVoteEVM } from '../../lib/evm';
 
 export default function VotePage() {
   const [externalNullifier, setExternalNullifier] = useState('');
   const [signal, setSignal] = useState('');
-  const [proof, setProof] = useState<any>(null);
+  const [proof, setProof] = useState<MembershipProof | null>(null);
   const [generating, setGenerating] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [txHash, setTxHash] = useState<string>('');

--- a/app/src/lib/evm.ts
+++ b/app/src/lib/evm.ts
@@ -1,4 +1,6 @@
 import { ethers } from 'ethers';
+import type { Eip1193Provider } from 'ethers';
+import type { MembershipProof } from './zk';
 
 const abi = [
   {
@@ -23,20 +25,12 @@ export async function castVoteEVM({
   args
 }: {
   address: string;
-  args: {
-    a: bigint[];
-    b: bigint[][];
-    c: bigint[];
-    root: bigint;
-    nullifierHash: bigint;
-    signalHash: bigint;
-    externalNullifier: bigint;
-  };
+  args: MembershipProof;
 }) {
-  // Assuming MetaMask or wallet is available
-  if (!(window as any).ethereum) throw new Error('No wallet found');
+  const { ethereum } = window as typeof window & { ethereum?: Eip1193Provider };
+  if (!ethereum) throw new Error('No wallet found');
 
-  const provider = new ethers.BrowserProvider((window as any).ethereum);
+  const provider = new ethers.BrowserProvider(ethereum);
   const signer = await provider.getSigner();
   const contract = new ethers.Contract(address, abi, signer);
 

--- a/app/src/lib/zk.ts
+++ b/app/src/lib/zk.ts
@@ -1,6 +1,45 @@
-export async function proveMembership(input: any) {
-  // @ts-ignore
-  const snarkjs = await import('snarkjs');
+export type MembershipProveInput = {
+  identity_secret: string;
+  pathElements: string[];
+  pathIndex: string[];
+  merkle_root: string;
+  external_nullifier: string;
+  sig: string;
+  nullifier_hash: string;
+  signal_binding: string;
+};
+
+type FullProofResult = {
+  proof: {
+    pi_a: string[];
+    pi_b: string[][];
+    pi_c: string[];
+  };
+  publicSignals: string[];
+};
+
+type SnarkJs = {
+  groth16: {
+    fullProve(
+      input: MembershipProveInput,
+      wasm: ArrayBuffer,
+      zkey: ArrayBuffer
+    ): Promise<FullProofResult>;
+  };
+};
+
+export type MembershipProof = {
+  a: bigint[];
+  b: bigint[][];
+  c: bigint[];
+  root: `0x${string}`;
+  nullifierHash: bigint;
+  signalHash: bigint;
+  externalNullifier: bigint;
+};
+
+export async function proveMembership(input: MembershipProveInput): Promise<MembershipProof> {
+  const snarkjs = (await import('snarkjs')) as SnarkJs;
 
   const wasmResponse = await fetch('/membership.wasm');
   const wasmBuffer = await wasmResponse.arrayBuffer();
@@ -8,13 +47,18 @@ export async function proveMembership(input: any) {
   const zkeyResponse = await fetch('/membership.zkey');
   const zkeyBuffer = await zkeyResponse.arrayBuffer();
 
-  const { proof, publicSignals } = await snarkjs.groth16.fullProve(input, wasmBuffer, zkeyBuffer);
+  const { proof, publicSignals } = await snarkjs.groth16.fullProve(
+    input,
+    wasmBuffer,
+    zkeyBuffer
+  );
 
   const a = proof.pi_a.slice(0, 2).map((x: string) => BigInt(x));
   const b = proof.pi_b.map((row: string[]) => row.map((x: string) => BigInt(x)));
   const c = proof.pi_c.slice(0, 2).map((x: string) => BigInt(x));
 
-  const root = BigInt(publicSignals[0]);
+  const rootBigInt = BigInt(publicSignals[0]);
+  const root = `0x${rootBigInt.toString(16).padStart(64, '0')}` as `0x${string}`;
   const nullifierHash = BigInt(publicSignals[1]);
   const signalHash = BigInt(publicSignals[2]);
   const externalNullifier = BigInt(publicSignals[3]);

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/app/types/snarkjs/index.d.ts
+++ b/app/types/snarkjs/index.d.ts
@@ -1,0 +1,20 @@
+import type { MembershipProveInput } from '../../src/lib/zk';
+
+type FullProofResult = {
+  proof: {
+    pi_a: string[];
+    pi_b: string[][];
+    pi_c: string[];
+  };
+  publicSignals: string[];
+};
+
+declare module 'snarkjs' {
+  export const groth16: {
+    fullProve(
+      input: MembershipProveInput,
+      wasm: ArrayBuffer,
+      zkey: ArrayBuffer
+    ): Promise<FullProofResult>;
+  };
+}


### PR DESCRIPTION
## Summary
- format the membership proof root as a 0x-prefixed bytes32 string and export typed proof/input helpers
- update the EVM vote submission helper to accept the typed proof and tighten provider handling
- provide ambient snarkjs types and tsconfig wiring so lint/build succeed without @ts-ignore

## Testing
- pnpm lint
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0de75945c83219003c6d1c7b151a6